### PR TITLE
Update build and publish to be more flexible

### DIFF
--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -1,39 +1,10 @@
-name: Build and publish backend docker image
+name: Publish backend docker image
 
-on:
-  push:
-    branches: [ main ]
+on: workflow_dispatch
 
 jobs:
-  check:
-    
-    runs-on: ubuntu-latest
-    outputs:
-      hasChanges: ${{steps.check_files.outputs.hasChanges}}
-    steps: 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: check modified files
-        id: check_files
-        run: |
-          echo "========== check paths of modified files =========="
-          git diff --name-only HEAD^ HEAD > files.txt
-          while IFS= read -r file
-          do
-          echo $file
-          if [[ $file == backend/* ]]; then
-              echo "Backend files changed. Setting build trigger variable"
-              echo "hasChanges=true" >> $GITHUB_OUTPUT
-              break
-          fi
-          done < files.txt
-  
   build:
     runs-on: ubuntu-latest
-    needs: check
-    if: needs.check.outputs.hasChanges == 'true'
     steps:
 
       - name: Checkout code

--- a/.github/workflows/publish-frontend.yml
+++ b/.github/workflows/publish-frontend.yml
@@ -1,39 +1,26 @@
-name: Build and publish frontend docker image
+name: Publish docker image
 
-on:
-  push:
-    branches: [ main ]
-
+on: 
+  workflow_dispatch:
+    inputs:
+      serviceName:
+        description: 'Docker image to be published'
+        required: true
+        type: choice
+        options:
+        - backend
+        - frontend
+        - translation-service
 jobs:
-  check:
-    
+  log-input:
     runs-on: ubuntu-latest
-    outputs:
-      hasChanges: ${{steps.check_files.outputs.hasChanges}}
-    steps: 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: check modified files
-        id: check_files
-        run: |
-          echo "========== check paths of modified files =========="
-          git diff --name-only HEAD^ HEAD > files.txt
-          while IFS= read -r file
-          do
-          echo $file
-          if [[ $file == frontend/* ]]; then
-              echo "frontend files changed. Setting build trigger variable"
-              echo "hasChanges=true" >> $GITHUB_OUTPUT
-              break
-          fi
-          done < files.txt
-  
+    steps:
+      - run: |
+          echo "Service name: $SERVICE_NAME"
+        env:
+          SERVICE_NAME: ${{ inputs.serviceName }}
   build:
     runs-on: ubuntu-latest
-    needs: check
-    if: needs.check.outputs.hasChanges == 'true'
     steps:
 
       - name: Checkout code
@@ -62,7 +49,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ./frontend
+          context: "./{{SERVICE_NAME}}"
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           

--- a/frontend/src/Translate.tsx
+++ b/frontend/src/Translate.tsx
@@ -10,7 +10,7 @@ interface Translation {
 }
 
 async function getTranslation(inputValue: string): Promise<TranslationResponse | string> {
-    let translateUrl = `http://localhost:3001/translate?target_lang=ES&text=${inputValue}`
+    let translateUrl = `https://zwsmith.me/api/translate?target_lang=ES&text=${inputValue}`
     let response = await fetch(translateUrl, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
This PR is the first step in an attempt to make the publish workflow flexible by allowing it to be run manually and to support selecting which service image should be built and published to docker hub.
Additionally I updated the URL for the translation api to hit the production url. I need to update that be an environment variable that gets provided at build time so the switch between dev and prod is seamless.