### PR TITLE
Set up word CRUD operations for API

### DIFF
--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -1,13 +1,17 @@
+import { Kysely, PostgresDialect } from "kysely";
 import { pool } from "./dbconfig";
-export async function testDb() {
-    try {
-        const res = await pool.query('SELECT NOW()');
-        if (res) {
-            console.log("DB connection succeeded.");
-        } else {
-            console.log("DB connection failed.");
-        }
-    } catch (error) {
-        console.log(`DB connection failed: ${error}`);
+import { Database } from "./types";
+export async function testDbConnection() {
+    const res = await pool.query('SELECT NOW()');
+    if (res) {
+        console.log("DB connection succeeded.");
+    } else {
+        throw Error("DB connection failed.");
     }
 }
+
+const dialect = new PostgresDialect({ pool: pool });
+
+export const db = new Kysely<Database>({
+    dialect,
+});

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -1,0 +1,24 @@
+import {
+    Generated,
+    Insertable,
+    Selectable,
+} from 'kysely';
+
+export interface Database {
+    word: WordTable;
+    language: LanguageTable;
+}
+
+export interface WordTable {
+    word_id: Generated<number>;
+    word_text: string;
+    language_code: string;
+}
+export interface LanguageTable {
+    language_code: string;
+}
+
+export type Word = Selectable<WordTable>;
+export type NewWord = Insertable<WordTable>;
+
+export type Language = Selectable<LanguageTable>;

--- a/backend/src/db/types.ts
+++ b/backend/src/db/types.ts
@@ -2,6 +2,7 @@ import {
     Generated,
     Insertable,
     Selectable,
+    Updateable,
 } from 'kysely';
 
 export interface Database {
@@ -19,6 +20,7 @@ export interface LanguageTable {
 }
 
 export type Word = Selectable<WordTable>;
-export type NewWord = Insertable<WordTable>;
+export type WordInsert = Insertable<WordTable>;
+export type WordUpdate = Updateable<WordTable>;
 
 export type Language = Selectable<LanguageTable>;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,6 @@
 import { Express } from "express";
 import { CorsOptions } from "cors";
-import { testDb as testDbConnection } from "./db/database";
+import { testDbConnection as testDbConnection } from "./db/database";
 import { App } from "./app";
 
 const devCorsOptions: CorsOptions = {

--- a/backend/src/v1/controllers/wordController.ts
+++ b/backend/src/v1/controllers/wordController.ts
@@ -25,9 +25,16 @@ class WordControllerImpl implements WordController {
         res.json(words);
     };
     getWord = async (req: Request, res: Response) => {
-        const id = parseInt(req.params.id);
-        let word = await this.repository.getWord(id);
-        res.json(word);
+        try {
+            const id = parseInt(req.params.id);
+            if (!id) {
+                res.status(400).send("Error: Bad Request");
+            }
+            let word = await this.repository.getWord(id);
+            res.json(word);
+        } catch (error) {
+            res.status(500).send("Error getting word");
+        }
     };
     addWord = async (req: Request, res: Response) => {
         const { body } = req;
@@ -42,16 +49,45 @@ class WordControllerImpl implements WordController {
             let result = await this.repository.insertWord(insertData);
             res.status(200).json({
                 message: "Insert succeeded",
-                word: result
+                result: result
             });
         } catch (error) {
             res.status(500).send("Error adding word to db.");
         }
     };
     updateWord = async (req: Request, res: Response) => {
-        throw Error("not implemented");
+        const { body, params } = req;
+        if (!params.id || !body.text || !body.languageCode) {
+            res.status(400).send("Error: Bad Request");
+        }
+        try {
+            const updateData = {
+                id: parseInt(params.id),
+                text: body.text,
+                languageCode: body.languageCode
+            };
+            let result = await this.repository.updateWord(updateData);
+            res.status(200).json({
+                message: "Update succeeded",
+                result: result
+            });
+        } catch (error) {
+            res.status(500).send("Error adding word to db.");
+        }
     };
     deleteWord = async (req: Request, res: Response) => {
-        throw Error("not implemented");
+        const id = parseInt(req.params.id);
+        if (!id) {
+            res.status(400).send("Error: Bad Request");
+        }
+        try {
+            let result = await this.repository.deleteWord(id);
+            res.status(200).json({
+                message: "Update succeeded",
+                result: result
+            });
+        } catch (error) {
+            res.status(500).send("Error adding word to db.");
+        }
     };
 };

--- a/backend/src/v1/controllers/wordController.ts
+++ b/backend/src/v1/controllers/wordController.ts
@@ -1,31 +1,57 @@
 import { Request, Response } from "express";
+import { ProvideWordRepository, WordRepository } from "../data/repositories/wordRepository";
 
-interface WordController {
-    getWords: (req: Request, res: Response) => void;
-    getWord: (req: Request, res: Response) => void;
-    addWord: (req: Request, res: Response) => void;
-    updateWord: (req: Request, res: Response) => void;
-    deleteWord: (req: Request, res: Response) => void;
+export interface WordController {
+    getWords: (req: Request, res: Response) => Promise<void>;
+    getWord: (req: Request, res: Response) => Promise<void>;
+    addWord: (req: Request, res: Response) => Promise<void>;
+    updateWord: (req: Request, res: Response) => Promise<void>;
+    deleteWord: (req: Request, res: Response) => Promise<void>;
 };
 
-export function WordController(): WordController {
-    return WordControllerImpl;
+export function ProvideWordController(): WordController {
+    return new WordControllerImpl(ProvideWordRepository());
 }
 
-const WordControllerImpl: WordController = {
-    getWords: function (req: Request, res: Response): void {
-        res.send("Get all words");
-    },
-    getWord: function (req: Request, res: Response): void {
-        res.send("Get word by ID");
-    },
-    addWord: function (req: Request, res: Response): void {
-        res.send("Add a new word");
-    },
-    updateWord: function (req: Request, res: Response): void {
-        res.send("Update an existing word");
-    },
-    deleteWord: function (req: Request, res: Response): void {
-        res.send("Delete an existing word");
+class WordControllerImpl implements WordController {
+
+    repository: WordRepository = ProvideWordRepository();
+    constructor(repository: WordRepository) {
+        this.repository = repository;
     }
+
+    getWords = async (req: Request, res: Response) => {
+        let words = await this.repository.getWords();
+        res.json(words);
+    };
+    getWord = async (req: Request, res: Response) => {
+        const id = parseInt(req.params.id);
+        let word = await this.repository.getWord(id);
+        res.json(word);
+    };
+    addWord = async (req: Request, res: Response) => {
+        const { body } = req;
+        if (!body.text || !body.languageCode) {
+            res.status(400).send("Error: Bad Request");
+        }
+        try {
+            const insertData = {
+                text: body.text,
+                languageCode: body.languageCode
+            };
+            let result = await this.repository.insertWord(insertData);
+            res.status(200).json({
+                message: "Insert succeeded",
+                word: result
+            });
+        } catch (error) {
+            res.status(500).send("Error adding word to db.");
+        }
+    };
+    updateWord = async (req: Request, res: Response) => {
+        throw Error("not implemented");
+    };
+    deleteWord = async (req: Request, res: Response) => {
+        throw Error("not implemented");
+    };
 };

--- a/backend/src/v1/data/models/models.ts
+++ b/backend/src/v1/data/models/models.ts
@@ -5,11 +5,11 @@ export type Translation = {
 };
 
 export type Word = {
-    id: string;
+    id: number;
     text: string,
     language: Language;
 };
 
 export type Language = {
-    languageCode: string;
+    code: string;
 };

--- a/backend/src/v1/data/models/models.ts
+++ b/backend/src/v1/data/models/models.ts
@@ -7,7 +7,7 @@ export type Translation = {
 export type Word = {
     id: number;
     text: string,
-    language: Language;
+    languageCode: string;
 };
 
 export type Language = {

--- a/backend/src/v1/data/repositories/wordRepository.ts
+++ b/backend/src/v1/data/repositories/wordRepository.ts
@@ -1,36 +1,62 @@
 import { Word } from "../models/models";
-
-interface WordRepository {
-    getWords(filterParams: {}): Word[];
-    getWord(id: string): Word;
-    addWord(data: AddWordData): void;
-    updateWord(word: Word): void;
-    deleteWord(id: string): void;
+import { db } from "../../../db/database";
+import { InsertResult } from "kysely";
+export interface WordRepository {
+    getWords(languageCode?: string): Promise<Word[]>;
+    getWord(id: number): Promise<Word>;
+    insertWord(data: InsertWordData): Promise<{ id: number; }>;
+    updateWord(word: Word): Promise<void>;
+    deleteWord(id: number): Promise<void>;
 };
 
 const WordRepositoryImpl: WordRepository = {
-    getWords: function (filterParams: {}): Word[] {
+    getWords: async (languageCode: string): Promise<Word[]> => {
+        let query = db.selectFrom("word").selectAll();
+        if (languageCode) {
+            query.where("language_code", "=", languageCode);
+        }
+        let result = await query.execute();
+        return result.map((entity) => {
+            return {
+                id: entity.word_id,
+                text: entity.word_text,
+                language: { code: entity.language_code }
+            };
+        });
+    },
+    getWord: async (id: number): Promise<Word> => {
+        let data = await db.selectFrom("word")
+            .selectAll()
+            .where("word.word_id", "=", id)
+            .executeTakeFirstOrThrow();
+
+        return {
+            id: data?.word_id,
+            text: data?.word_text,
+            language: { code: data?.language_code }
+        };
+    },
+    insertWord: async (data: InsertWordData): Promise<{ id: number; }> => {
+        let query = db.insertInto("word").values({
+            word_text: data.text,
+            language_code: data.languageCode
+        });
+        let result = await query.returning("word_id").executeTakeFirstOrThrow();
+        return { id: result.word_id };
+    },
+    updateWord: async (word: Word): Promise<void> => {
         throw new Error("Function not implemented.");
     },
-    getWord: function (id: string): Word {
-        throw new Error("Function not implemented.");
-    },
-    addWord: function (data: AddWordData): void {
-        throw new Error("Function not implemented.");
-    },
-    updateWord: function (word: Word): void {
-        throw new Error("Function not implemented.");
-    },
-    deleteWord: function (id: string): void {
+    deleteWord: async (id: number): Promise<void> => {
         throw new Error("Function not implemented.");
     }
 };
 
-export function WordRepository(): WordRepository {
+export function ProvideWordRepository(): WordRepository {
     return WordRepositoryImpl;
 };
 
-export type AddWordData = {
+export type InsertWordData = {
     text: string,
     languageCode: string;
 };

--- a/backend/src/v1/routes/wordRouter.ts
+++ b/backend/src/v1/routes/wordRouter.ts
@@ -1,17 +1,17 @@
 import { Router } from "express";
 
-import { WordController } from "../controllers/wordController";
+import { ProvideWordController, WordController } from "../controllers/wordController";
 
 export const WordRouter = Router();
 
-const controller = WordController();
+const controller: WordController = ProvideWordController();
 
 WordRouter.get("/", controller.getWords);
 
-WordRouter.get("/:translationId", controller.getWord);
+WordRouter.get("/:id", controller.getWord);
 
 WordRouter.post("/", controller.addWord);
 
-WordRouter.put("/:translationId", controller.updateWord);
+WordRouter.put("/:id", controller.updateWord);
 
-WordRouter.delete(":translationId", controller.deleteWord);
+WordRouter.delete("/:id", controller.deleteWord);


### PR DESCRIPTION
This PR add CRUD operations to the backend API for the app.
Changes include:
- Defining and exposing the types for [kysely query builder](https://kysely.dev/)
- Updating the `WordRepository` interface and implementation to handling interacting with the db
- Updating the `WordController` to make use of the new functionality on the repository
- Some general reformatting for clarity/cleanliness